### PR TITLE
Fix filename handling.

### DIFF
--- a/dashproxy.py
+++ b/dashproxy.py
@@ -259,7 +259,7 @@ class DashDownloader(HasLogger):
         return self.mpd_base_url + dest # TODO remove hardcoded arrd
 
     def write(self, dest, content):
-        dest = dest[0:dest.rfind('?')]
+        dest = dest.split('?')[0]
         dest = os.path.join(self.proxy.output_dir, dest)
         f = open(dest, 'wb')
         f.write(content)


### PR DESCRIPTION
`dest.rfind('?')` returns -1 if there's no '?' in `dest` and this causes the last char of `dest` to be chopped off mistakenly.